### PR TITLE
feat: Change map tile layer to Esri satellite imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="https://cdn.jsdelivr.net/npm/esri-leaflet@3.0.17/dist/esri-leaflet.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -17,12 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }).addTo(map);
 
     // 2. Add a Custom Tile Layer
-    // Using a minimalist Stamen Toner Lite tile layer for a clean, unobtrusive look.
-    L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', {
-        attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        minZoom: 8,
-        maxZoom: 16
-    }).addTo(map);
+    // Using Esri's satellite imagery for a more realistic view.
+    L.esri.basemapLayer('Imagery').addTo(map);
 
     // 3. Monastery Data
     const monasteries = [


### PR DESCRIPTION
- Replaced the Stamen watercolor tile layer with Esri's satellite imagery basemap.
- Added the esri-leaflet plugin to support the new basemap layer.